### PR TITLE
Use negotiated KEX instead of preferred

### DIFF
--- a/russh/src/client/kex.rs
+++ b/russh/src/client/kex.rs
@@ -37,14 +37,7 @@ impl KexInit {
         debug!("i0 = {:?}", i0);
 
         let mut kex = KEXES
-            .get(
-                &self
-                    .algo
-                    .as_ref()
-                    .map(|x| &x.kex)
-                    .or_else(|| config.preferred.kex.first())
-                    .ok_or(crate::Error::NoCommonKexAlgo)?,
-            )
+            .get(&algo.kex)
             .ok_or(crate::Error::UnknownAlgo)?
             .make();
 


### PR DESCRIPTION
The KEX algo was always the first of the preferred KEX one.

Instead relies on the KEX algo that was negotiated with server rather than the preferred one.